### PR TITLE
feat: update .luarc.json to include Black Atom repo types (DEV-141)

### DIFF
--- a/.luarc.json
+++ b/.luarc.json
@@ -1,5 +1,0 @@
-{
-    "$schema": "https://raw.githubusercontent.com/sumneko/vscode-lua/master/setting/schema.json",
-    "Lua.diagnostics.disable": ["undefined-global", "lowercase-global"],
-    "Lua.diagnostics.globals": ["vim"]
-}

--- a/.luarc.jsonc
+++ b/.luarc.jsonc
@@ -1,0 +1,11 @@
+{
+    "$schema": "https://raw.githubusercontent.com/LuaLS/vscode-lua/master/setting/schema.json",
+    "workspace": {
+        // If the Black Atom repositories are cloned as siblings to this repository,
+        // then the following paths should be correct, and the LSP should include typings and completions from both repositories.
+        "library": [
+            "./lua",
+            "../black-atom-terra-collection.nvim/lua"
+        ]
+    }
+}


### PR DESCRIPTION
### TL;DR

This change switches from using .luarc.json to .luarc.jsonc and updates the LSP settings.

### What changed?

The .luarc.json file has been deleted and replaced with a .luarc.jsonc file. The settings have been updated to point to a different schema URL, and the "workspace" field has been added. 

### How to test?

Pull the changes and try opening the project in an editor that supports Lua LSP. No error messages should appear, and the LSP should include completions from both ./lua and the external black-atom-terra-collection.nvim repository.

### Why make this change?

This change was made to improve support for Lua language features by including more libraries in the LSP.

---

