### PR TITLE
docs(README): add installation instructions for lazy.nvim (DEV-160)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,23 @@ This is all a work in progress.
 
 ---
 
+## Installation
+
+Install the plugin with your favourite package manager. 
+Example with [lazy.nvim](https://github.com/folke/lazy.nvim):
+
+```lua
+---@type LazyPluginSpec
+return {
+    "black-atom-industries/nvim",
+    name = "black-atom",
+    priority = 1000,
+    ---@module "black-atom"
+    ---@type BlackAtom.Config
+    opts = {},
+}
+```
+
 ## Development
 
 ### Linting

--- a/lua/black-atom/config.lua
+++ b/lua/black-atom/config.lua
@@ -1,7 +1,7 @@
 local M = {}
 
 -- Escaped plugin name. Used to find its own installation path.
-M.plugin_name = "black%-atom%.nvim"
+M.plugin_name = "black%-atom"
 
 ---@type BlackAtom.Config
 M.default = {


### PR DESCRIPTION
- docs(README): include code snippet for lazy.nvim installation
- fix(config): correct escaped plugin name in config.lua